### PR TITLE
add support for inline CKEDITOR editor 

### DIFF
--- a/ckeditor/ckeditor.js
+++ b/ckeditor/ckeditor.js
@@ -17,7 +17,15 @@ webix.protoUI({
 
 		window.CKEDITOR_BASEPATH = webix.codebase+"ckeditor/";
 		webix.require("ckeditor/ckeditor.js", function(){
-			this._3rd_editor = CKEDITOR.replace( this.config.textAreaID, {
+			var initMethod;
+			if(this.config.editorType === "inline") {
+				CKEDITOR.disableAutoInline = true;
+				initMethod = "inline";
+			} else {
+				initMethod = "replace";
+			}
+			
+			this._3rd_editor = CKEDITOR.[initMethod]( this.config.textAreaID, {
 				toolbar: this.config.toolbar,
 				language: this.config.language,
 				width:this.$width -2,

--- a/ckeditor/ckeditor.js
+++ b/ckeditor/ckeditor.js
@@ -25,7 +25,7 @@ webix.protoUI({
 				initMethod = "replace";
 			}
 			
-			this._3rd_editor = CKEDITOR.[initMethod]( this.config.textAreaID, {
+			this._3rd_editor = CKEDITOR[initMethod]( this.config.textAreaID, {
 				toolbar: this.config.toolbar,
 				language: this.config.language,
 				width:this.$width -2,

--- a/ckeditor/ckeditor.js
+++ b/ckeditor/ckeditor.js
@@ -35,7 +35,7 @@ webix.protoUI({
 		this._init_ckeditor_once = function(){};
 	},
 	_set_inner_size:function(x, y){
-		if (!this._3rd_editor || !this._3rd_editor.container || !this.$width) return;
+		if (!this._3rd_editor || !this._3rd_editor.container || !this.$width || this.config.editorType === "inline") return;
 		this._3rd_editor.resize(x, y);
 	},
 	$setSize:function(x,y){


### PR DESCRIPTION
Use parameter `editorType: "inline"` when initializing the component.

Example:

```js
webix.ui({
    id: "editor",
    view: "ckeditor",
    editorType: "inline",
    value: "..." //text and HTML markup
});
```