### PR TITLE
add resize support to the ace editor wrapper

### DIFF
--- a/ace/ace.js
+++ b/ace/ace.js
@@ -8,6 +8,13 @@ webix.protoUI({
 		this._waitEditor = webix.promise.defer();
 		this.$ready.push(this._render_cm_editor);
 	},
+	$setSize: function(w, h) {
+		if (webix.ui.view.prototype.$setSize.call(this, w, h)) {
+			if (this._editor) {
+				this._editor.resize();
+			}
+		}
+	},
 	_render_cm_editor:function(){		
 		if (this.config.cdn === false){
 			this._render_when_ready();


### PR DESCRIPTION
Without this change, resizing behaves very strangely. The underlying Ace editor needs to be informed of size changes to fix this.