### PR TITLE
feat: provide custom config

### DIFF
--- a/ckeditor/ckeditor.js
+++ b/ckeditor/ckeditor.js
@@ -1,81 +1,84 @@
 webix.protoUI({
 	name:"ckeditor",
 	$init:function(config){
-		this.$view.className += " webix_selectable";
-		this._waitEditor = webix.promise.defer();
-
-		var tid = config.textAreaID = "t"+webix.uid();
-		this.$view.innerHTML = "<textarea id='"+tid+"'>"+config.value+"</textarea>";
-
-		this.$ready.push(this._init_ckeditor_once);
+	  this.$view.className += " webix_selectable";
+	  this._waitEditor = webix.promise.defer();
+  
+	  var tid = config.textAreaID = "t"+webix.uid();
+	  this.$view.innerHTML = "<textarea id='"+tid+"'>"+config.value+"</textarea>";
+  
+	  this.$ready.push(this._init_ckeditor_once);
 	},
 	defaults:{
-		editorConfig: {
-			language:"en",
-			toolbar: [
-				[ 'Bold', 'Italic', '-', 'NumberedList', 'BulletedList', '-', 'Link', 'Unlink' ],
-				[ 'FontSize', 'TextColor', 'BGColor' ]
-			]
-		}
+	  language:"en",
+	  toolbar: [
+		[ 'Bold', 'Italic', '-', 'NumberedList', 'BulletedList', '-', 'Link', 'Unlink' ],
+		[ 'FontSize', 'TextColor', 'BGColor' ]
+	  ],
+	  editorConfig: {}
 	},
 	_init_ckeditor_once:function(){		
-		if (this.config.cdn === false){
-			webix.delay( webix.bind( this._render_ckeditor, this) );
-			return;
-		};
-
-		var cdn = this.config.cdn || "//cdn.ckeditor.com/4.13.0/standard/";
-	
-		window.CKEDITOR_BASEPATH = cdn;			
-		webix.require([cdn+"/ckeditor.js"])
+	  if (this.config.cdn === false){
+		webix.delay( webix.bind( this._render_ckeditor, this) );
+		return;
+	  };
+  
+	  var cdn = this.config.cdn || "//cdn.ckeditor.com/4.13.0/standard/";
+  
+	  window.CKEDITOR_BASEPATH = cdn;			
+	  webix.require([cdn+"/ckeditor.js"])
 		.then( webix.bind(this._render_ckeditor, this) )
 		.catch(function(e){
-			console.log(e);
-		});	
+		console.log(e);
+	  });	
 	},
 	_render_ckeditor:function(){
-		var initMethod = "replace";
-		if(this.config.editorType === "inline") {
-			CKEDITOR.disableAutoInline = true;
-			initMethod = "inline";
-			this.$view.style["overflow-y"] = "auto";
-		};
-
-		var barHeight = 70; // toolbar + bottombar, as initial sizes are set to the editable area
-		this._editor = CKEDITOR[initMethod](this.config.textAreaID, webix.extend({
-			width:this.$width,
-			height:this.$height-barHeight,
-			resize_enabled:false
-		}, this.config.editorConfig));
-		this._waitEditor.resolve(this._editor);
+	  var initMethod = "replace";
+	  if(this.config.editorType === "inline") {
+		CKEDITOR.disableAutoInline = true;
+		initMethod = "inline";
+		this.$view.style["overflow-y"] = "auto";
+	  };
+  
+	  var barHeight = 70; // toolbar + bottombar, as initial sizes are set to the editable area
+	  var config = webix.extend({
+		toolbar: this.config.toolbar,
+		language: this.config.language,
+		width:this.$width,
+		height:this.$height-barHeight,
+		resize_enabled:false
+	  }, this.config.editorConfig);
+	  
+	  this._editor = CKEDITOR[initMethod](this.config.textAreaID, config);
+	  this._waitEditor.resolve(this._editor);
 	},
 	_set_inner_size:function(x, y){
-		if (!this._editor || !this._editor.container || !this.$width || this.config.editorType === "inline") return;
-		this._editor.resize(x, y);
+	  if (!this._editor || !this._editor.container || !this.$width || this.config.editorType === "inline") return;
+	  this._editor.resize(x, y);
 	},
 	$setSize:function(x,y){
-		if (webix.ui.view.prototype.$setSize.call(this, x, y)){
-			this._set_inner_size(x,y);
-		}
+	  if (webix.ui.view.prototype.$setSize.call(this, x, y)){
+		this._set_inner_size(x,y);
+	  }
 	},
 	setValue:function(value){
-		this.config.value = value;
-
-		if (this._editor && this._editor.status === "ready")
-			this._editor.setData(value);
-		else webix.delay(function(){
-			this.setValue(value);
-		},this,[],100);
+	  this.config.value = value;
+  
+	  if (this._editor && this._editor.status === "ready")
+		this._editor.setData(value);
+	  else webix.delay(function(){
+		this.setValue(value);
+	  },this,[],100);
 	},
 	getValue:function(){
-		return this._editor?this._editor.getData():this.config.value;
+	  return this._editor?this._editor.getData():this.config.value;
 	},
 	focus:function(){
-		this._focus_await = true;
-		if (this._editor)
-			this._editor.focus();
+	  this._focus_await = true;
+	  if (this._editor)
+		this._editor.focus();
 	},
 	getEditor:function(waitEditor){
-		return waitEditor?this._waitEditor:this._editor;
+	  return waitEditor?this._waitEditor:this._editor;
 	}
-}, webix.ui.view);
+  }, webix.ui.view);

--- a/ckeditor/ckeditor.js
+++ b/ckeditor/ckeditor.js
@@ -10,11 +10,13 @@ webix.protoUI({
 		this.$ready.push(this._init_ckeditor_once);
 	},
 	defaults:{
-		language:"en",
-		toolbar: [
-			[ 'Bold', 'Italic', '-', 'NumberedList', 'BulletedList', '-', 'Link', 'Unlink' ],
-			[ 'FontSize', 'TextColor', 'BGColor' ]
-		]
+		editorConfig: {
+			language:"en",
+			toolbar: [
+				[ 'Bold', 'Italic', '-', 'NumberedList', 'BulletedList', '-', 'Link', 'Unlink' ],
+				[ 'FontSize', 'TextColor', 'BGColor' ]
+			]
+		}
 	},
 	_init_ckeditor_once:function(){		
 		if (this.config.cdn === false){
@@ -40,13 +42,11 @@ webix.protoUI({
 		};
 
 		var barHeight = 70; // toolbar + bottombar, as initial sizes are set to the editable area
-		this._editor = CKEDITOR[initMethod]( this.config.textAreaID, {
-			toolbar: this.config.toolbar,
-			language: this.config.language,
+		this._editor = CKEDITOR[initMethod](this.config.textAreaID, webix.extend({
 			width:this.$width,
 			height:this.$height-barHeight,
 			resize_enabled:false
-		});
+		}, this.config.editorConfig));
 		this._waitEditor.resolve(this._editor);
 	},
 	_set_inner_size:function(x, y){


### PR DESCRIPTION
не уверен, можно заменить `editorConfig` на `config`, но выглядит немного странно (this.config.config), но вроде что-то такое же уже юзается в интеграции с ckeditor5, т.е. скорее всего нужно унифицировать

